### PR TITLE
Fix: ImageViewer zoom behavior while cached

### DIFF
--- a/src/components/views/image-viewer/ImageViewer.view.tsx
+++ b/src/components/views/image-viewer/ImageViewer.view.tsx
@@ -55,6 +55,7 @@ export const ImageViewerView: FC<ImageViewerViewProps> = ({ imageViewer }) => {
       onClick={() => {
         endZoom();
         setLayout({
+          // FIX: these need to be read from the defaults for where the image is requested
           navigation: true,
           content: true,
           canvas: true,
@@ -67,7 +68,9 @@ export const ImageViewerView: FC<ImageViewerViewProps> = ({ imageViewer }) => {
         }
         onLoad();
         updateMotionStyles(imageViewer, motionStyles);
-        animate.start(produceFullVariant(imageViewer));
+        process.nextTick(() => {
+          animate.start(produceFullVariant(imageViewer));
+        });
         setLayout({
           navigation: false,
           content: false,


### PR DESCRIPTION
- Close 19 by wrapping `animate.start` in `process.nextTick`. This
  resolves the issue of image zoom failing when the image is cached
  by the browser.
- Add a `FIX` todo to for the non-zoom state of the page layout.
