### PR TITLE
Chore(devcontainer): Upgrade devcontainer image

### DIFF
--- a/.docker/docker-compose.dev.yaml
+++ b/.docker/docker-compose.dev.yaml
@@ -2,20 +2,8 @@ version: "3.9"
 
 services:
   webclient:
-    image: utkusarioglu/node-devcontainer:17-slim.0.1
+    image: utkusarioglu/node-devcontainer:17-slim.0.3
     volumes:
       - type: bind
         source: ..
         target: /utkusarioglu/utkusarioglu-com
-      - type: bind
-        source: ~/dev/projects/utkusarioglu-root-ca/p-256/server
-        target: /utkusarioglu/utkusarioglu-com/.certs/server
-        read_only: true
-        volume:
-          nocopy: true
-      - type: bind
-        source: ~/dev/projects/utkusarioglu-root-ca/p-256/root
-        target: /utkusarioglu/utkusarioglu-com/.certs/root
-        read_only: true
-        volume:
-          nocopy: true


### PR DESCRIPTION
- Upgrade devcontainer image to 17-slim.0.3. This update features
  multiple enhancements related to DX.
- Remove certificate mounts from `docker-compose.dev.yml`. This is
  done to allow the repo to run on codespaces. Any certificate need
  by this repo will either have to be present in the workspace or will
  need to be provided through secrets.
