### PR TITLE
Changes in About, Musings, Resume and Credits pages

### DIFF
--- a/assets/about.yml
+++ b/assets/about.yml
@@ -1,0 +1,42 @@
+name: Utku Sarioglu
+items:
+  - type: image
+    alt: "Utku Sarioglu"
+    credits: "photo by Onur Sarioglu"
+    src: _assets/images/utku-1x1.jpg
+  - type: paragraph
+    content: |
+      I'm an economist by degree but I have spent a considerable time studying 
+      music, math, physics and programming. In addition to these primary 
+      interests of mine, I have also been involved with photography, 
+      advertising and marketing through the professional roles I have served.
+      
+  - type: paragraph
+    content: |
+      I tend to thrive under challenges I understand. It's a very common thing 
+      for me to lose track of time while working on something I feel passionate 
+      about. The downside of this is that I spend some of my days upset with 
+      myself if I cannot get something to reach a state I'm satisfied with.
+
+  - type: paragraph
+    content: |
+      I tend to rise to leadership positions in most of the teams I participate 
+      in. I rarely intend for this to happen but I am usually level-headed and 
+      open-minded in many situations while many others give in to frustrations 
+      that are induced through exhaustion or stress. Heads usually end up 
+      turning to me to guide the conversation or to resolve the gridlock.
+
+  - type: paragraph
+    content: |
+      I want to help build a world where true information is readily available, 
+      where there is trust in society through implementation of the right 
+      carrots and the fewest sticks. I believe that we are on the cusp of many 
+      great changes that can help realize these ideals.
+
+  - type: paragraph
+    content: |
+      I spend my free time reading articles and watching videos about 
+      prehistoric civilizations, art history, contemporary civilian and 
+      military engineering projects. I also enjoy taking photos and processing 
+      them. But most of all, my free time is devoted to music. I am an avid 
+      classical music, jazz, rock and metal listener and performer.

--- a/assets/credits.yml
+++ b/assets/credits.yml
@@ -1,0 +1,49 @@
+name: Utku Sarioglu
+page: Credits
+
+inspiration: 
+  title: Inspiration
+  remarks: 
+    - The seeds of the design of the page came from the background canvas.
+      The eye-catching curves of the perlin noise generator guided the rest 
+      of the design; with essentially everything either flowing with or 
+      contrasting against the curves that are present on most of the pages.
+
+sourceCode:
+  title: Source Code
+  list: 
+    - title: Github
+      remarks: 
+        - The entirety of the source code
+      url: https://www.github.com/utkusarioglu/utkusarioglu-com
+
+techStack:
+  title: Tech stack
+  list: 
+    - title: JS Framework
+      value: NextJS
+    - title: CSS Framework
+      value: TailwindCSS
+    - title: Main language
+      value: Typescript
+    - title: Unit testing library
+      value: Jest
+    - title: E2E testing library
+      value: Cypress
+    - title: Animation library
+      value: Framer Motion
+    - title: PDF creation tool
+      value: Puppeteer
+    - title: CI/CD infrastructure tool
+      value: Github Actions
+    - title: Infrastructure management tool
+      value: Terraform
+    - title: Cloud Provider
+      value: AWS S3
+    - title: Cloud Cache
+      value: AWS Cloudfront
+    - title: Development environment
+      value: devcontainer
+      # TODO Find the original library for perlin noise
+    - title: Canvas library adapted from
+      value: <someone>

--- a/assets/musings.yml
+++ b/assets/musings.yml
@@ -1,6 +1,10 @@
+name: Utku Sarioglu
+page: Musings
+
 remarks: 
   - |
     Some small (and big) projects that I carry out in my spare time
+
 sections:
   - title: Amusement Projects
     remarks: 
@@ -26,7 +30,9 @@ sections:
         href: /musings/kamyon
         remarks:
           - |
-            A collaboration with Ennuriye in aim of gathering amusing and insightful examples of what is colloquially called "trucker jokes" in Turkey. 
+            A collaboration with Ennuriye in aim of gathering amusing and 
+            insightful examples of what is colloquially called "trucker jokes" 
+            in Turkey. 
 
   - title: Container Templates
     remarks:

--- a/assets/resume.yml
+++ b/assets/resume.yml
@@ -1,4 +1,6 @@
 name: Utku Sarioglu
+page: Resume
+
 introduction:
   title: Introduction
   print: false
@@ -13,6 +15,7 @@ introduction:
       handling complexity. Experienced in international contexts and handling tricky
       personnel and clients. Proven to be capable of creating wholistic solutions,
       meeting complex requirements and handling stressful tasks.
+
 contact:
   title: Contact
   print: false
@@ -286,6 +289,7 @@ relevantWorkExperience:
           Wrote productivity modules using VBA, AutoIt, which reduced daily
           workload by 60%. While primarily working as the current accounts'
           manager.
+
 relevantCertifications:
   title: Relevant Certifications
   list:

--- a/src/components/layouts/resume/ResumeScreen.layout.tsx
+++ b/src/components/layouts/resume/ResumeScreen.layout.tsx
@@ -1,15 +1,16 @@
 import { type FC } from "react";
 import { type Resume } from "_types/resume.types";
+import ContentCardBackgroundLayout from "_layouts/content-card/ContentCardBackground.layout";
+import ContentCardItemLayout from "_layouts/content-card/ContentCardItem.layout";
+import ContentCardSectionView from "_views/content-card/ContentCardSection.view";
+
+import ResumeCertificationLi from "_views/resume-screen/ResumeScreenCertificationLi.view";
+import ResumeContactLi from "_views/resume-screen/ResumeScreenContactLi.view";
+import ResumeDownload from "_views/resume-screen/ResumeScreenDownload.view";
+import ResumeEducationLi from "_views/resume-screen/ResumeScreenEducationLi.view";
 import ResumeIntroduction from "_views/resume-screen/ResumeScreenIntroduction.view";
-import ResumeSection from "_views/content-card/ContentCardSection.view";
 import ResumeSkills from "_views/resume-screen/ResumeScreenSkills.view";
 import ResumeWorkExperienceLi from "_views/resume-screen/ResumeScreenWorkExperienceLi.view";
-import ResumeCertificationLi from "_views/resume-screen/ResumeScreenCertificationLi.view";
-import ResumeEducationLi from "_views/resume-screen/ResumeScreenEducationLi.view";
-import ContentCardBackgroundLayout from "_layouts/content-card/ContentCardBackground.layout";
-import ResumeContactLi from "_views/resume-screen/ResumeScreenContactLi.view";
-import ContentCardItemLayout from "_layouts/content-card/ContentCardItem.layout";
-import ResumeDownload from "_views/resume-screen/ResumeScreenDownload.view";
 
 export interface ResumeScreenLayoutProps {
   resume: Resume;
@@ -31,7 +32,7 @@ const ResumeScreenLayout: FC<ResumeScreenLayoutProps> = ({
       <ResumeSkills {...skills} />
     </ContentCardBackgroundLayout>
     <ContentCardBackgroundLayout>
-      <ResumeSection
+      <ContentCardSectionView
         {...relevantWorkExperience}
         listItemComponent={({ item }) => (
           <ContentCardItemLayout>
@@ -41,13 +42,13 @@ const ResumeScreenLayout: FC<ResumeScreenLayoutProps> = ({
       />
     </ContentCardBackgroundLayout>
     <ContentCardBackgroundLayout>
-      <ResumeSection
+      <ContentCardSectionView
         {...relevantCertifications}
         listItemComponent={({ item }) => <ResumeCertificationLi {...item} />}
       />
     </ContentCardBackgroundLayout>
     <ContentCardBackgroundLayout>
-      <ResumeSection
+      <ContentCardSectionView
         {...education}
         listItemComponent={({ item }) => (
           <ContentCardItemLayout>
@@ -57,7 +58,7 @@ const ResumeScreenLayout: FC<ResumeScreenLayoutProps> = ({
       />
     </ContentCardBackgroundLayout>
     <ContentCardBackgroundLayout>
-      <ResumeSection
+      <ContentCardSectionView
         {...contact}
         listItemComponent={({ item }) => <ResumeContactLi {...item} />}
       />

--- a/src/components/views/credits/CreditsInspiration.view.tsx
+++ b/src/components/views/credits/CreditsInspiration.view.tsx
@@ -1,0 +1,20 @@
+import { type FC } from "react";
+import P from "_primitives/paragraph/P.primitive";
+import H2 from "_primitives/headings/H2.primitive";
+import { type CreditsInspiration } from "_types/credits.types";
+
+type CreditsInspirationViewProps = CreditsInspiration;
+
+const CreditsInspirationView: FC<CreditsInspirationViewProps> = ({
+  title,
+  remarks,
+}) => (
+  <div className="px-5 mb-10">
+    <H2>{title}</H2>
+    {remarks.map((paragraph) => (
+      <P key={paragraph}>{paragraph}</P>
+    ))}
+  </div>
+);
+
+export default CreditsInspirationView;

--- a/src/components/views/credits/CreditsTechStackItem.view.tsx
+++ b/src/components/views/credits/CreditsTechStackItem.view.tsx
@@ -1,0 +1,18 @@
+import { type FC } from "react";
+import P from "_primitives/paragraph/P.primitive";
+import H3 from "_primitives/headings/H3.primitive";
+import { type CreditsTechStackItem } from "_types/credits.types";
+
+type CreditsTechStackItemViewProps = CreditsTechStackItem;
+
+const CreditsTechStackItemView: FC<CreditsTechStackItemViewProps> = ({
+  title,
+  value,
+}) => (
+  <div>
+    <H3>{title}</H3>
+    <P>{value}</P>
+  </div>
+);
+
+export default CreditsTechStackItemView;

--- a/src/components/views/credits/SourceCodeItem.view.tsx
+++ b/src/components/views/credits/SourceCodeItem.view.tsx
@@ -1,0 +1,23 @@
+import { type FC } from "react";
+import ContentCardLinkView from "_views/content-card/ContentCardLink.view";
+import H3 from "_primitives/headings/H3.primitive";
+import ContentCardItemLayout from "_layouts/content-card/ContentCardItem.layout";
+import { type CreditsSourceCode } from "_types/credits.types";
+import { COLORS } from "_config";
+
+type SourceCodeItemViewProps = CreditsSourceCode;
+
+const SourceCodeItemView: FC<SourceCodeItemViewProps> = ({
+  title,
+  remarks,
+  url,
+}) => (
+  <ContentCardLinkView href={url}>
+    <ContentCardItemLayout>
+      <H3>{title}</H3>
+      <div className={COLORS.paragraph}>{remarks}</div>
+    </ContentCardItemLayout>
+  </ContentCardLinkView>
+);
+
+export default SourceCodeItemView;

--- a/src/components/views/resume-screen/ResumeScreenDownload.view.tsx
+++ b/src/components/views/resume-screen/ResumeScreenDownload.view.tsx
@@ -5,22 +5,24 @@ import { COLORS } from "_config";
 import ContentCardLinkView from "_views/content-card/ContentCardLink.view";
 import H3 from "_primitives/headings/H3.primitive";
 
+const RESUME_LIST = [
+  {
+    title: "Letter",
+    remarks: "North American standard",
+    folder: "letter",
+  },
+  {
+    title: "A4",
+    remarks: "Standard format for Europe and the rest of the world",
+    folder: "a4",
+  },
+];
+
 const ResumeScreenDownloadView = () => (
   <ContentCardBackgroundLayout>
     <ContentCardSectionView
       title="Download Resume"
-      list={[
-        {
-          title: "Letter",
-          remarks: "North American standard",
-          folder: "letter",
-        },
-        {
-          title: "A4",
-          remarks: "Standard format for Europe and the rest of the world",
-          folder: "a4",
-        },
-      ]}
+      list={RESUME_LIST}
       listItemComponent={({ item: { title, folder, remarks } }) => (
         <ContentCardLinkView
           href={`/_next/static/resume/${folder}/utku-sarioglu-resume.pdf`}

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,8 +135,8 @@ export const HEX = {
     light: process.env.HIGHEST_LIGHT,
   },
   shadow: {
-    light: process.env.LOW_LIGHT,
-    dark: process.env.HIGH_DARK,
+    light: process.env.TERTIARY_LIGHT,
+    dark: process.env.TERTIARY_DARK,
   },
 };
 

--- a/src/pages/about.page.tsx
+++ b/src/pages/about.page.tsx
@@ -3,38 +3,42 @@ import { MAX_W_CONTENT } from "_config";
 import ContentLayout from "_layouts/content/Content.layout";
 import EnhancedImage from "_primitives/enhanced-image/EnhancedImage.primitive";
 import P from "_primitives/paragraph/P.primitive";
+import { parse } from "yaml";
+import { readFileSync } from "fs";
+import type { About, AboutPageProps } from "_types/about.types";
 
-const content = [
-  " Quisque at enim suscipit, luctus felis sed, vehicula risus. Fusce sit amet diam consequat, viverra quam in, consectetur mi. Praesent lectus elit, convallis non metus et, sodales feugiat sapien. Donec neque urna, rutrum at risus a, malesuada tempus ex. Mauris ultrices massa sem, pretium tincidunt risus finibus eu. Aliquam erat volutpat. Nullam pharetra lacus eget fermentum congue. In hac habitasse platea dictumst. Sed venenatis nibh non quam ultricies gravida. Ut porta, dolor eget fermentum porta, massa diam posuere ante, in consequat ligula turpis et eros. Curabitur scelerisque tellus in sem iaculis accumsan. Vestibulum viverra nunc auctor semper lacinia. Nulla facilisi. Donec sed enim molestie, tempus justo in, ornare ex. Nulla faucibus tortor a nulla sodales, in pellentesque nisl ornare. ",
-  " In malesuada nisi felis, non tincidunt nisl malesuada ut. Sed eu fermentum felis, vel consequat erat. Fusce turpis libero, vestibulum ut gravida ac, euismod et libero. Vestibulum nunc metus, bibendum nec fringilla eu, tristique eu mi. Maecenas placerat nulla id dolor consequat vehicula. Pellentesque volutpat purus quis tortor ullamcorper, eget consequat ipsum fringilla. Mauris molestie, massa nec tempus pulvinar, felis risus rutrum nibh, quis suscipit odio nunc a velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Donec bibendum ullamcorper dolor, sit amet eleifend erat efficitur vitae. Vestibulum placerat dolor nec varius gravida. Mauris molestie augue nec leo porta efficitur. Curabitur tincidunt consectetur quam ac dapibus. Praesent rutrum libero sapien, id porttitor ex rutrum et. ",
-  " Sed posuere ut neque nec fringilla.Nulla porta felis non elit lobortis rhoncus.Sed facilisis dignissim pharetra.Ut bibendum ullamcorper lectus vel ullamcorper.Etiam vestibulum urna ante, laoreet rutrum nunc fringilla nec.Maecenas vel maximus ex.Duis nec lectus elit.Sed iaculis enim non ultrices tristique.Vestibulum vehicula vulputate nibh ac ornare.Nunc condimentum tellus sem, a rhoncus erat porttitor eget.Nunc euismod libero et augue porta consequat.Donec auctor dui id lacus dignissim euismod.Mauris porttitor quis tellus eu mollis.Vivamus convallis efficitur malesuada.Fusce et eros a ex ullamcorper ornare.Duis a ex sed nisl aliquet mollis a faucibus dui. ",
-];
+export function getStaticProps() {
+  const about = parse(
+    readFileSync("assets/about.yml", { encoding: "UTF-8" })
+  ) as About;
 
-interface AboutPageProps {}
+  return {
+    props: {
+      about,
+    },
+  };
+}
 
-const AboutPage: FC<AboutPageProps> = () => {
+const AboutPage: FC<AboutPageProps> = ({ about }) => {
   return (
     <ContentLayout>
-      <EnhancedImage
-        className="rounded-full"
-        alt="Utku Sarioglu"
-        credits="photo by Onur Sarioglu"
-        src={require("_assets/images/utku-1x1.jpg")}
-        maxResponsiveWidth={MAX_W_CONTENT}
-      />
-      {content.map((paragraph) => (
-        <P key={paragraph}>{paragraph}</P>
-      ))}
-      <EnhancedImage
-        className="rounded-md"
-        alt="Musings title image"
-        credits="photo by Utku Sarioglu"
-        src={require("_assets/images/old-ship.jpg")}
-        maxResponsiveWidth={MAX_W_CONTENT}
-      />
-      {content.map((paragraph) => (
-        <P key={paragraph}>{paragraph}</P>
-      ))}
+      {about.items.map((item) => {
+        switch (item.type) {
+          case "paragraph":
+            return <P key={item.content}>{item.content}</P>;
+          case "image":
+            return (
+              <EnhancedImage
+                className="rounded-full"
+                alt={item.alt}
+                credits={item.credits}
+                // src={require(item.src)}
+                src={require("_assets/images/utku-1x1.jpg")}
+                maxResponsiveWidth={MAX_W_CONTENT}
+              />
+            );
+        }
+      })}
     </ContentLayout>
   );
 };

--- a/src/pages/about.page.tsx
+++ b/src/pages/about.page.tsx
@@ -5,7 +5,11 @@ import EnhancedImage from "_primitives/enhanced-image/EnhancedImage.primitive";
 import P from "_primitives/paragraph/P.primitive";
 import { parse } from "yaml";
 import { readFileSync } from "fs";
-import type { About, AboutPageProps } from "_types/about.types";
+import type { About } from "_types/about.types";
+
+export interface AboutPageProps {
+  about: About;
+}
 
 export function getStaticProps() {
   const about = parse(

--- a/src/pages/credits.page.tsx
+++ b/src/pages/credits.page.tsx
@@ -1,16 +1,69 @@
+import { type FC } from "react";
 import ContentLayout from "_layouts/content/Content.layout";
-import P from "_primitives/paragraph/P.primitive";
+import { MAX_W_CONTENT } from "_config";
+import EnhancedImage from "_primitives/enhanced-image/EnhancedImage.primitive";
+import VerticalMarginsLayout from "_layouts/vertical-margins/VerticalMargins.layout";
+import ContentCardSectionView from "_views/content-card/ContentCardSection.view";
+import ContentCardItemLayout from "_layouts/content-card/ContentCardItem.layout";
+import ContentCardBackgroundLayout from "_layouts/content-card/ContentCardBackground.layout";
+import { parse } from "yaml";
+import { readFileSync } from "fs";
+import { type Credits } from "_types/credits.types";
+import SourceCodeItemView from "../components/views/credits/SourceCodeItem.view";
+import CreditsInspirationView from "../components/views/credits/CreditsInspiration.view";
+import CreditsTechStackItemView from "../components/views/credits/CreditsTechStackItem.view";
 
-const content = ["Runs on aws", "Also, other things"];
+interface CreditsPageProps {
+  credits: Credits;
+}
 
-const ResumePage = () => {
+export function getStaticProps() {
+  const credits = parse(
+    readFileSync("assets/credits.yml", { encoding: "UTF-8" })
+  ) as Credits;
+
+  return {
+    props: {
+      credits,
+    },
+  };
+}
+
+const CreditsPage: FC<CreditsPageProps> = ({
+  credits: { inspiration, sourceCode, techStack },
+}) => {
   return (
-    <ContentLayout>
-      {content.map((paragraph) => (
-        <P key={paragraph}>{paragraph}</P>
-      ))}
+    <ContentLayout verticalMargins={false}>
+      <VerticalMarginsLayout className="print:hidden">
+        <EnhancedImage
+          className="rounded-md"
+          alt="Resume title image"
+          credits="photo by Utku Sarioglu"
+          src={require("_assets/images/waves-and-bird.jpg")}
+          maxResponsiveWidth={MAX_W_CONTENT}
+        />
+      </VerticalMarginsLayout>
+
+      <CreditsInspirationView {...inspiration} />
+      <ContentCardBackgroundLayout>
+        <ContentCardSectionView
+          {...sourceCode}
+          listItemComponent={({ item }) => <SourceCodeItemView {...item} />}
+        />
+      </ContentCardBackgroundLayout>
+
+      <ContentCardBackgroundLayout>
+        <ContentCardSectionView
+          {...techStack}
+          listItemComponent={({ item }) => (
+            <ContentCardItemLayout>
+              <CreditsTechStackItemView {...item} />
+            </ContentCardItemLayout>
+          )}
+        />
+      </ContentCardBackgroundLayout>
     </ContentLayout>
   );
 };
 
-export default ResumePage;
+export default CreditsPage;

--- a/src/types/about.types.ts
+++ b/src/types/about.types.ts
@@ -1,18 +1,20 @@
+import { type Named } from "./content.types";
+
 interface AboutParagraph {
   type: "paragraph";
   content: string;
 }
+
 interface AboutImage {
   type: "image";
   alt: string;
   credits: string;
   src: string;
 }
+
 type AboutItems = AboutParagraph | AboutImage;
+
 export type About = {
-  name: string;
+  page: "About";
   items: AboutItems[];
-};
-export interface AboutPageProps {
-  about: About;
-}
+} & Named;

--- a/src/types/about.types.tsx
+++ b/src/types/about.types.tsx
@@ -1,0 +1,18 @@
+interface AboutParagraph {
+  type: "paragraph";
+  content: string;
+}
+interface AboutImage {
+  type: "image";
+  alt: string;
+  credits: string;
+  src: string;
+}
+type AboutItems = AboutParagraph | AboutImage;
+export type About = {
+  name: string;
+  items: AboutItems[];
+};
+export interface AboutPageProps {
+  about: About;
+}

--- a/src/types/content.types.ts
+++ b/src/types/content.types.ts
@@ -29,3 +29,7 @@ export type Confided = {
 export type Screenable = {
   screen: boolean;
 };
+
+export type Named = {
+  name: "Utku Sarioglu";
+};

--- a/src/types/credits.types.ts
+++ b/src/types/credits.types.ts
@@ -1,0 +1,19 @@
+import type { Section, Titled, Remarked, Entity, Named } from "./content.types";
+
+export type CreditsTechStackItem = Titled & {
+  value: string;
+};
+
+export type CreditsSourceCode = Titled &
+  Remarked & {
+    url: string;
+  };
+
+export type CreditsInspiration = Entity;
+
+export type Credits = {
+  page: "Credits";
+  inspiration: CreditsInspiration;
+  sourceCode: Section<CreditsSourceCode>;
+  techStack: Section<CreditsTechStackItem>;
+} & Named;

--- a/src/types/musings.types.ts
+++ b/src/types/musings.types.ts
@@ -1,5 +1,13 @@
-import type { Section, Titled, Remarked, Linked } from "_types/content.types";
+import type {
+  Section,
+  Titled,
+  Remarked,
+  Linked,
+  Named,
+} from "_types/content.types";
 
 export type Musings = {
+  page: "Musings";
   sections: Section<Titled & Remarked & Linked>[];
-} & Remarked;
+} & Remarked &
+  Named;

--- a/src/types/resume.types.ts
+++ b/src/types/resume.types.ts
@@ -7,6 +7,7 @@ import type {
   Screenable,
   Entity,
   Listed,
+  Named,
 } from "./content.types";
 
 export type Skill = Titled & Partial<Remarked & Confided & Printable>;
@@ -45,12 +46,12 @@ export type Education = {
 
 type Introduction = Entity;
 
-export interface Resume {
-  name: string;
+export type Resume = {
+  page: "Resume";
   introduction: Introduction;
   contact: Section<ContactListItem>;
   skills: Skills;
   relevantWorkExperience: Section<WorkExperience>;
   relevantCertifications: Section<Certification>;
   education: Section<Education>;
-}
+} & Named;


### PR DESCRIPTION
This PR contains multiple related enhancements for pages:
* Implements some draft text for About page
* Implements the credits page with a few missing aspects, which are created as issues.
* Refactors Resume and Musing pages.
* Alters the shadow color for the dark mode

Please refer to the following commits for details:
- Feat: first pass at about page
- Chore(types): About page type adjustments
- Feat(page): Implement "credits" page
- Refactor(page): Resume page types, component names
- Chore(page): Musings page types and alignments
- Feat: Alter shadow color in dark mode
