### PR TITLE
Chore(certs): Update certs paths

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -47,11 +47,12 @@ jobs:
       - name: Move certificates
         if: steps.resume-artifacts-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p ".certs/server"
-          mkdir -p ".certs/root/certs"
-          mv server.crt server.key .certs/server/
+          mkdir -p .certs/server/{certs,private}
+          mkdir -p .certs/root/certs
+          mv server.crt .certs/server/certs/
+          mv server.key .certs/server/private/
           mv root.crt .certs/root/certs/
-          # This is done to pleas the pptruser: the user in 
+          # This is done to please the pptruser: the user in 
           # puppeteer container.
           sudo chmod -R +r .certs
 

--- a/scripts/start-ssl-proxy.sh
+++ b/scripts/start-ssl-proxy.sh
@@ -4,5 +4,5 @@ echo "Starting local-ssl-proxy"
 yarn local-ssl-proxy \
   --source 443 \
   --target 3000 \
-  --key ./.certs/server/server.key \
-  --cert ./.certs/server/server.crt
+  --key ./.certs/server/private/server.key \
+  --cert ./.certs/server/certs/chain.crt


### PR DESCRIPTION
- Update folder structure used for certs. The changes in this commit
  reflect changes that happen on gitignored files, and CI files that are
  created and destroyed during the runtime of jobs. Certs now all follow
  the same folder structure at all levels, hence this change is
  required.

[no ci]
