### PR TITLE
Fix: Resume overflows

### DIFF
--- a/.puppeteer/src/index.js
+++ b/.puppeteer/src/index.js
@@ -3,12 +3,12 @@ const puppeteer = require("puppeteer");
 const artifactsPath = "/home/pptruser/artifacts";
 const url = "https://www.utkusarioglu.com/resume";
 
-const variants = [
+const PAPER_FORMAT_VARIANTS = [
   {
     format: "a4",
     margin: {
-      x: 50,
-      y: 55,
+      x: 52,
+      y: 70,
     },
   },
   {
@@ -34,7 +34,7 @@ const variants = [
   });
   await page.screenshot({ path: `${artifactsPath}/screenshots/resume.png` });
 
-  await variants.reduce(async (chain, { format, margin }) => {
+  await PAPER_FORMAT_VARIANTS.reduce(async (chain, { format, margin }) => {
     chain = chain.then(() =>
       page.pdf({
         displayHeaderFooter: false,

--- a/assets/resume.yml
+++ b/assets/resume.yml
@@ -218,7 +218,7 @@ relevantWorkExperience:
       companyName: HSO, LLC - Oz Medical DBA
       location: Pleasanton, CA. USA
       start: Oct, 2019
-      finish: Mar, 2021
+      finish: Mar, 2022
       remarks:
         - |
           Built a scalable online sales management system aiding the product 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
       base: ["1.1rem", { lineHeight: "1.6rem" }],
     },
     gridTemplateColumns: {
-      resume: "50vw 15vw auto",
+      resume: "50vw 13vw auto",
     },
     gridTemplateRows: {
       resume: "min max",


### PR DESCRIPTION
- Close #32 by fixing resume overflows in A4 and Letter. The checks
  were made on puppeteer output, not browser print output. The fix
  required changed in `tailwind.config` and `.puppeteer/src/index.js`
  values.
- Rename const variable SCREAMING_SNAKE_CASE in
  `.puppeteer/src/index.js` to follow const value convention.
