### PR TITLE
Fix: Build PDF CI pipeline TLS error fix attempt

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -40,7 +40,7 @@ jobs:
         if: steps.resume-artifacts-cache.outputs.cache-hit != 'true'
         uses: kofemann/action-create-certificate@v0.0.4
         with:
-          hostcert: "server.crt"
+          hostcert: "chain.crt"
           hostkey: "server.key"
           cachain: "root.crt"
 

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate server certificates
         uses: kofemann/action-create-certificate@v0.0.4
         with:
-          hostcert: "../../..${{ github.workspace }}/.certs/server/server.crt"
+          hostcert: "../../..${{ github.workspace }}/.certs/server/chain.crt"
           hostkey: "../../..${{ github.workspace }}/.certs/server/server.key"
           cachain: "../../..${{ github.workspace }}/.certs/root/root.crt"
       - name: Run Cypress tests


### PR DESCRIPTION
- Attempt fix the file not found erros that pop up during pdf creation.
  This issue is thought to stem from the recent change in the folder
  structure for the certificates.
