### PR TITLE
Fix #36: Disable paper chain item animations

### DIFF
--- a/src/components/views/paper-chain/PaperChain.view.tsx
+++ b/src/components/views/paper-chain/PaperChain.view.tsx
@@ -1,7 +1,5 @@
 import PaperChainItemView from "_views/paper-chain-item/PaperChainItem.view";
-import MOl from "_primitives/framer-motion/m-ol.primitive";
-import MLi from "_primitives/framer-motion/m-li.primitive";
-import { FC } from "react";
+import type { FC } from "react";
 import type { PaperChainEntry } from "_views/paper-chain-item/PaperChainItem.view.types";
 
 interface PaperChainViewProps {
@@ -10,13 +8,13 @@ interface PaperChainViewProps {
 
 const PaperChainView: FC<PaperChainViewProps> = ({ list }) => {
   return (
-    <MOl className="mb-20" variants={variants.container}>
+    <ol>
       {list.map((item) => (
-        <MLi layout key={item.content} variants={variants.item}>
+        <li key={item.content}>
           <PaperChainItemView item={item} key={item.timestamp} />
-        </MLi>
+        </li>
       ))}
-    </MOl>
+    </ol>
   );
 };
 


### PR DESCRIPTION
- Fix paper chain not appearing on screen by disabling the animations.
  this has to be a temporary solution until the framer motion issue
  is resolved.
