### PR TITLE
Fix: Cloudfront cache invalidation path

### DIFF
--- a/scripts/aws-create-invalidation.sh
+++ b/scripts/aws-create-invalidation.sh
@@ -30,4 +30,4 @@ fi
 echo "Creating cloudfront invalidation for id: '$distribution_id'..."
 aws cloudfront create-invalidation \
   --distribution-id $distribution_id \
-  --paths "/"
+  --paths '/*'


### PR DESCRIPTION
- Cloudfront cache invalidation path has been switched from '/' to '/*'.
  The previous path did not remove static object, causing obsolete
  objects to be served to the web.
