### PR TITLE
Fix #69: Footer link visibility in crated pdfs

### DIFF
--- a/src/components/layouts/footer/Footer.layout.tsx
+++ b/src/components/layouts/footer/Footer.layout.tsx
@@ -4,7 +4,7 @@ import c from "classnames";
 
 const FooterLayout = () => {
   return (
-    <div className="flex items-center">
+    <div className="flex items-center print:hidden">
       <Link href="/credits">
         <a
           className={c(


### PR DESCRIPTION
- Fixes #69 by adding `print:hidden` to `Footer.layout`.
